### PR TITLE
fix mapstructure decoding on embedded structures

### DIFF
--- a/basic2token/basic2token.go
+++ b/basic2token/basic2token.go
@@ -18,7 +18,7 @@ type Basic2TokenConfig struct {
 	Basic2Token *Basic2TokenOptions `mapstructure:"basic2token" json:"basic2token" yaml:"basic2token"`
 }
 type Basic2TokenOptions struct {
-	utils.ClientRouteOption
+	utils.ClientRouteOption `mapstructure:",squash"`
 	// Uri to retrieve access token e.g.: https://my.uaa.local/oauth/token
 	AccessTokenUri string `mapstructure:"access_token_uri" json:"access_token_uri" yaml:"access_token_uri"`
 	// Client id which will connect user on behalf him

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -11,7 +11,7 @@ type Oauth2Config struct {
 	Oauth2 *Oauth2Options `mapstructure:"oauth2" json:"oauth2" yaml:"oauth2"`
 }
 type Oauth2Options struct {
-	utils.ClientRouteOption
+	utils.ClientRouteOption `mapstructure:",squash"`
 	// enable oauth2 middleware
 	Enabled bool `mapstructure:"enabled" json:"enabled" yaml:"enabled"`
 	// Uri to create authoriation code e.g.: https://my.uaa.local/oauth/authorize


### PR DESCRIPTION
Embedded types are load loaded by mapstructure unless we give ```squash``` directive.

I searched for Embedded type usage in all middlewares and only found *Basic2Token* and *OAuth2*. Another look may be useful.

